### PR TITLE
Feature/upload page add phone and email

### DIFF
--- a/CDTS Blazor/CDNApplication.csproj
+++ b/CDTS Blazor/CDNApplication.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <DocumentationFile>bin\Debug\netcoreapp3.1\CDNApplicationForm.xml</DocumentationFile>
     <NoWarn>1591;1701;1702</NoWarn>
   </PropertyGroup>

--- a/CDTS Blazor/Models/PageModels/UploadDocumentPageModel.cs
+++ b/CDTS Blazor/Models/PageModels/UploadDocumentPageModel.cs
@@ -15,6 +15,16 @@
         public string CdnNumber { get; set; }
 
         /// <summary>
+        ///  Gets or sets phone number.
+        /// </summary>
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        ///  Gets or sets email address.
+        /// </summary>
+        public string EmailAddress { get; set; }
+
+        /// <summary>
         ///     Gets or sets the certificate type.
         /// </summary>
         public string CertificateType { get; set; }

--- a/CDTS Blazor/PageValidators/UploadDocumentValidator.cs
+++ b/CDTS Blazor/PageValidators/UploadDocumentValidator.cs
@@ -30,6 +30,16 @@
                     .Matches(new Regex("^[a-zA-Z0-9]*$"))
                     .WithMessage(localizer.GetString("CdnFormatText"));
 
+            this.RuleFor(m => m.PhoneNumber)
+                .Cascade(CascadeMode.Stop)
+                    .NotEmpty()
+                    .WithMessage(localizer.GetString("PhoneNumberNotEmptyText"));
+            
+            this.RuleFor(m => m.EmailAddress)
+                .Cascade(CascadeMode.Stop)
+                    .EmailAddress()
+                    .WithMessage(localizer.GetString("EmailAddressFormatText"));
+
             this.RuleFor(m => m.CertificateType)
                 .NotEmpty()
                 .WithMessage(localizer.GetString("CertificateTypeNotEmptyText"));

--- a/CDTS Blazor/Pages/ReviewDocument.razor
+++ b/CDTS Blazor/Pages/ReviewDocument.razor
@@ -30,8 +30,16 @@ else
 
         <div class="panel-body">
             <div class="row">
-                <div class="col-md-3">@PageLocalizer["CDNNumber"]:</div>
-                <div class="col-md-3">@model.CdnNumber</div>
+                <div class="col-md-4">@PageLocalizer["CDNNumber"]:</div>
+                <div class="col-md-8">@model.CdnNumber</div>
+            </div>
+            <div class="row">
+                <div class="col-md-4">@PageLocalizer["PhoneNumber"]:</div>
+                <div class="col-md-8">@model.PhoneNumber</div>
+            </div>
+            <div class="row">
+                <div class="col-md-4">@PageLocalizer["EmailAddress"]:</div>
+                <div class="col-md-8">@model.EmailAddress</div>
             </div>
         </div>
     </div>
@@ -43,8 +51,8 @@ else
         </div>
         <div class="panel-body">
             <div class="row">
-                <div class="col-md-3">@PageLocalizer["SelectedCertificate"]:</div>
-                <div class="col-md-3">@model.CertificateType</div>
+                <div class="col-md-4">@PageLocalizer["SelectedCertificate"]:</div>
+                <div class="col-md-8">@model.CertificateType</div>
             </div>
         </div>
     </div>

--- a/CDTS Blazor/Pages/UploadDocument.razor
+++ b/CDTS Blazor/Pages/UploadDocument.razor
@@ -13,8 +13,6 @@
 
 <h1>@PageLocalizer["PageTitle"]</h1>
 
-<p>@PageLocalizer["PageDescription"]</p>
-
 <EditForm Model="@model" OnValidSubmit="HandleValidSubmit">
     <FluentValidationValidator />
     <ValidationSummary />

--- a/CDTS Blazor/Pages/UploadDocument.razor
+++ b/CDTS Blazor/Pages/UploadDocument.razor
@@ -18,26 +18,53 @@
 <EditForm Model="@model" OnValidSubmit="HandleValidSubmit">
     <FluentValidationValidator />
     <ValidationSummary />
-
-    <div class="form-group">
-        <div class="form-control-wrapper">
-            <label class="form-control-label required" for="@nameof(model.CdnNumber)">
-                @PageLocalizer["CDNLabel"] <strong class="required">@CommonLocalizer["Required"]</strong>
-            </label>
-            <InputText class="form-control" @bind-Value="@model.CdnNumber" id="@nameof(model.CdnNumber)" />
-            <ValidationMessage For="() => model.CdnNumber" />
+    <section class="panel panel-primary">
+        <header class="panel-heading">
+            <h5 class="panel-title">@PageLocalizer["EnterYourInformationPanelHeading"]</h5>
+        </header>
+        <div class="panel-body">
+            <div class="form-group">
+                <div class="form-control-wrapper">
+                    <label class="form-control-label required" for="@nameof(model.CdnNumber)">
+                        @PageLocalizer["CDNLabel"] <strong class="required">@CommonLocalizer["Required"]</strong>
+                    </label>
+                    <InputText class="form-control" @bind-Value="@model.CdnNumber" id="@nameof(model.CdnNumber)" />
+                    <ValidationMessage For="() => model.CdnNumber" />
+                </div>
+                <div class="form-control-wrapper">
+                    <label class="form-control-label required" for="@nameof(model.PhoneNumber)">
+                        @PageLocalizer["PhoneNumberLabel"] <strong class="required">@CommonLocalizer["Required"]</strong>
+                    </label>
+                    <InputText class="form-control" @bind-Value="@model.PhoneNumber" id="@nameof(model.PhoneNumber)" type="tel" />
+                    <ValidationMessage For="() => model.PhoneNumber" />
+                </div>
+                <div class="form-control-wrapper">
+                    <label class="form-control-label" for="@nameof(model.EmailAddress)">
+                        @PageLocalizer["EmailAddressLabel"]
+                    </label>
+                    <InputText class="form-control" @bind-Value="@model.EmailAddress" id="@nameof(model.EmailAddress)" type="email" />
+                    <ValidationMessage For="() => model.EmailAddress" />
+                </div>
+            </div>
         </div>
-    </div>
+    </section>
 
-    <div class="form-group">
-        <div class="form-control-wrapper">
-            <label class="form-control-label required">
-                @PageLocalizer["SelectCertificateLabel"] <strong class="required">@CommonLocalizer["Required"]</strong>
-            </label>
-            <TSelect Items="@certificateTypes" FieldName="EnglishName" OnSelectChangeFromChildEvent="CertificateTypeSelectionChanged" />
-            <ValidationMessage For="() => model.CertificateType" />
+    <section class="panel panel-primary">
+        <header class="panel-heading">
+            <h5 class="panel-title">@PageLocalizer["SelectCertificatePanelHeading"]</h5>
+        </header>
+        <div class="panel-body">
+            <div class="form-group">
+                <div class="form-control-wrapper">
+                    <label class="form-control-label required">
+                        @PageLocalizer["SelectCertificateLabel"] <strong class="required">@CommonLocalizer["Required"]</strong>
+                    </label>
+                    <TSelect Items="@certificateTypes" FieldName="EnglishName" OnSelectChangeFromChildEvent="CertificateTypeSelectionChanged" />
+                    <ValidationMessage For="() => model.CertificateType" />
+                </div>
+            </div>
         </div>
-    </div>
+    </section>
 
     <section class="panel panel-primary">
         <header class="panel-heading">
@@ -73,7 +100,11 @@
     </section>
 
     <button class=" btn btn-primary">
-        @CommonPageLocalizer["Next"]
+        @PageLocalizer["PrimaryButton"]
+    </button>
+
+    <button class=" btn btn-secondary" @onclick="HandlePreviousClick">
+        @CommonPageLocalizer["Previous"]
     </button>
 
 </EditForm>
@@ -95,9 +126,14 @@
 
     }
 
+    private void HandlePreviousClick()
+    {
+        NavigationManager.NavigateTo($"{NavigationManager.BaseUri}{LanguageCode}");
+    }
+
     async void HandleFileSelected(IFileListEntry[] files)
     {
-        
+
         if (string.IsNullOrWhiteSpace(model.FileDescription))
         {
             return;

--- a/CDTS Blazor/Resources/Pages/ReviewDocument.fr.resx
+++ b/CDTS Blazor/Resources/Pages/ReviewDocument.fr.resx
@@ -147,4 +147,10 @@
   <data name="YourInformation" xml:space="preserve">
     <value>Vos informations</value>
   </data>
+  <data name="EmailAddress" xml:space="preserve">
+    <value>Adresse électronique</value>
+  </data>
+  <data name="PhoneNumber" xml:space="preserve">
+    <value>Numéro de téléphone</value>
+  </data>
 </root>

--- a/CDTS Blazor/Resources/Pages/ReviewDocument.resx
+++ b/CDTS Blazor/Resources/Pages/ReviewDocument.resx
@@ -147,4 +147,10 @@
   <data name="YourInformation" xml:space="preserve">
     <value>Your information</value>
   </data>
+  <data name="EmailAddress" xml:space="preserve">
+    <value>Email address</value>
+  </data>
+  <data name="PhoneNumber" xml:space="preserve">
+    <value>Phone Number</value>
+  </data>
 </root>

--- a/CDTS Blazor/Resources/Pages/UploadDocument.fr.resx
+++ b/CDTS Blazor/Resources/Pages/UploadDocument.fr.resx
@@ -120,9 +120,6 @@
   <data name="PageTitle" xml:space="preserve">
     <value>Saisissez vos informations et ajoutez vos documents</value>
   </data>
-  <data name="PageDescription" xml:space="preserve">
-    <value>Remplissez ce formulaire avec vos informations et ajoutez vos documents.</value>
-  </data>
   <data name="CDNLabel" xml:space="preserve">
     <value>Entrez votre numéro de document de candidat (CDN)</value>
   </data>

--- a/CDTS Blazor/Resources/Pages/UploadDocument.fr.resx
+++ b/CDTS Blazor/Resources/Pages/UploadDocument.fr.resx
@@ -150,4 +150,19 @@
   <data name="AddAnotherFileText" xml:space="preserve">
     <value>Ajoutez un autre fichier</value>
   </data>
+  <data name="EmailAddressLabel" xml:space="preserve">
+    <value>Adresse électronique</value>
+  </data>
+  <data name="EnterYourInformationPanelHeading" xml:space="preserve">
+    <value>Saisissez vos informations</value>
+  </data>
+  <data name="PhoneNumberLabel" xml:space="preserve">
+    <value>Numéro de téléphone</value>
+  </data>
+  <data name="SelectCertificatePanelHeading" xml:space="preserve">
+    <value>Sélectionnez votre certificat</value>
+  </data>
+  <data name="PrimaryButton" xml:space="preserve">
+    <value>Procéder à l'examen</value>
+  </data>
 </root>

--- a/CDTS Blazor/Resources/Pages/UploadDocument.resx
+++ b/CDTS Blazor/Resources/Pages/UploadDocument.resx
@@ -120,9 +120,6 @@
   <data name="PageTitle" xml:space="preserve">
     <value>Enter your information and add your documents</value>
   </data>
-  <data name="PageDescription" xml:space="preserve">
-    <value>Fill in this form with your information and add your documents.</value>
-  </data>
   <data name="CDNLabel" xml:space="preserve">
     <value>Enter your Candidate Document Number (CDN)</value>
   </data>

--- a/CDTS Blazor/Resources/Pages/UploadDocument.resx
+++ b/CDTS Blazor/Resources/Pages/UploadDocument.resx
@@ -150,4 +150,19 @@
   <data name="AddAnotherFileText" xml:space="preserve">
     <value>Add another file</value>
   </data>
+  <data name="EmailAddressLabel" xml:space="preserve">
+    <value>Email address</value>
+  </data>
+  <data name="EnterYourInformationPanelHeading" xml:space="preserve">
+    <value>Enter your information</value>
+  </data>
+  <data name="PhoneNumberLabel" xml:space="preserve">
+    <value>Phone number</value>
+  </data>
+  <data name="SelectCertificatePanelHeading" xml:space="preserve">
+    <value>Select your certificate</value>
+  </data>
+  <data name="PrimaryButton" xml:space="preserve">
+    <value>Proceed to review</value>
+  </data>
 </root>

--- a/CDTS Blazor/Resources/Shared/Common.fr.resx
+++ b/CDTS Blazor/Resources/Shared/Common.fr.resx
@@ -135,4 +135,7 @@
   <data name="Submit" xml:space="preserve">
     <value>Soumettre</value>
   </data>
+  <data name="Previous" xml:space="preserve">
+    <value>Précédent</value>
+  </data>
 </root>

--- a/CDTS Blazor/Resources/Shared/Common.resx
+++ b/CDTS Blazor/Resources/Shared/Common.resx
@@ -135,4 +135,7 @@
   <data name="Submit" xml:space="preserve">
     <value>Submit</value>
   </data>
+  <data name="Previous" xml:space="preserve">
+    <value>Previous</value>
+  </data>
 </root>

--- a/CDTS Blazor/Resources/Validation/UploadDocumentErrorMessages.Designer.cs
+++ b/CDTS Blazor/Resources/Validation/UploadDocumentErrorMessages.Designer.cs
@@ -97,6 +97,24 @@ namespace CDNApplication.Resources.Validation {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Email address must be a valid format.
+        /// </summary>
+        internal static string EmailAddressFormatText {
+            get {
+                return ResourceManager.GetString("EmailAddressFormatText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Phone number is a required field.
+        /// </summary>
+        internal static string PhoneNumberNotEmptyText {
+            get {
+                return ResourceManager.GetString("PhoneNumberNotEmptyText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must upload at least 1 file..
         /// </summary>
         internal static string UploadedFilesNotEmptyText {

--- a/CDTS Blazor/Resources/Validation/UploadDocumentErrorMessages.fr.resx
+++ b/CDTS Blazor/Resources/Validation/UploadDocumentErrorMessages.fr.resx
@@ -129,6 +129,12 @@
   <data name="CertificateTypeNotEmptyText" xml:space="preserve">
     <value>Le type de certificat est un champ obligatoire.</value>
   </data>
+  <data name="EmailAddressFormatText" xml:space="preserve">
+    <value>L'adresse électronique doit avoir un format valide</value>
+  </data>
+  <data name="PhoneNumberNotEmptyText" xml:space="preserve">
+    <value>Le numéro de téléphone est un champ obligatoire</value>
+  </data>
   <data name="UploadedFilesNotEmptyText" xml:space="preserve">
     <value>Vous devez soumettre au moins 1 fichier.</value>
   </data>

--- a/CDTS Blazor/Resources/Validation/UploadDocumentErrorMessages.resx
+++ b/CDTS Blazor/Resources/Validation/UploadDocumentErrorMessages.resx
@@ -129,6 +129,12 @@
   <data name="CertificateTypeNotEmptyText" xml:space="preserve">
     <value>Certificate Type is a required field.</value>
   </data>
+  <data name="EmailAddressFormatText" xml:space="preserve">
+    <value>Email address must be a valid format</value>
+  </data>
+  <data name="PhoneNumberNotEmptyText" xml:space="preserve">
+    <value>Phone number is a required field</value>
+  </data>
   <data name="UploadedFilesNotEmptyText" xml:space="preserve">
     <value>You must upload at least 1 file.</value>
   </data>

--- a/CDTS Blazor/Startup.cs
+++ b/CDTS Blazor/Startup.cs
@@ -95,7 +95,6 @@ namespace CDNApplication
             services
                 .ConfigureGoCTemplateRequestLocalization(); // if GoC.WebTemplate-Components.Core (in NuGet) >= v2.1.1
 
-            
             services.AddHttpsRedirection(options =>
             {
                 options.RedirectStatusCode = StatusCodes.Status308PermanentRedirect;
@@ -149,8 +148,6 @@ namespace CDNApplication
 
                 return next(context);
             });
-
-            
 
             app.UseStaticFiles();
             app.UsePageSettingsMiddleware();


### PR DESCRIPTION
AB#44973 Add a confirmation email feature (confirmation page)
AB#46034 Add email field and phone number on upload page, and make upload page look like figma
AB#44953 Remove intro line to reduce redundancy (upload page)
AB#46128 Remove intro line from upload page
AB#44999 Include a 'review' page before the 'confirmation' page so users can double check their application
AB#46114 Add email and phone number to confirmation page