### PR TITLE
AB#49294:  Include Validation Message for Submission Type Field

### DIFF
--- a/CDTS Blazor/Pages/UploadDocument.razor
+++ b/CDTS Blazor/Pages/UploadDocument.razor
@@ -111,6 +111,7 @@
                                 </div>
                             }
                         </InputRadioGroup>
+                        <ValidationMessage For="() => model.SubmissionType" />
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
Not sure if this is necessary since a default value is set seemingly automatically but nonetheless added <ValidationMessage> tag to UploadDocument page for submission type field. I meant to add this to last pull request but I did not make it in time ;).